### PR TITLE
Handle refreshing slots in case of error: (error) CLUSTERDOWN Hash slot not served

### DIFF
--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -484,6 +484,10 @@ impl ClusterConnection {
                             // Sleep and retry.
                             let sleep_time = 2u64.pow(16 - retries.max(9)) * 10;
                             thread::sleep(Duration::from_millis(sleep_time));
+                            // Refresh slots incase of error: (error) CLUSTERDOWN Hash slot not served
+                            if kind == ErrorKind::ClusterDown && err.is_hash_slot_not_served() {
+                                self.refresh_slots()?;
+                            }
                             excludes.clear();
                             continue;
                         }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -504,6 +504,11 @@ impl RedisError {
         }
     }
 
+    /// Returns true if error was caused by: (error) CLUSTERDOWN Hash slot not served
+    pub fn is_hash_slot_not_served(&self) -> bool {
+        matches!(self.detail(), Some("Hash slot not served"))
+    }
+
     /// Returns the node the error refers to.
     ///
     /// This returns `(addr, slot_id)`.


### PR DESCRIPTION
The lib does not aware that the hash slot allocation has been changed in some scenarios, especially when using this redis server config: cluster-require-full-coverage no
This fix is to force the lib to refresh the hashslot mapping on above error.